### PR TITLE
Improve config parser and support time.Duration

### DIFF
--- a/cmd/minimal-server-monitoring/minimal-server-monitoring.go
+++ b/cmd/minimal-server-monitoring/minimal-server-monitoring.go
@@ -26,7 +26,7 @@ func makeStartupMessage(cfg *config.Config) notifier.Message {
 	startupMsg := fmt.Sprintf("Monitoring started:\n - %v notifier(s)", len(cfg.Notifiers))
 	startupMsg += fmt.Sprintf("\n - %v scraper(s):", len(cfg.Scrapers))
 	for scraperName, scraperCfg := range cfg.Scrapers {
-		startupMsg += fmt.Sprintf("\n  * %v (%v) every %v seconds", scraperName, scraperCfg.Type, scraperCfg.ScrapeInterval)
+		startupMsg += fmt.Sprintf("\n  * %v (%v) every %v", scraperName, scraperCfg.Type, scraperCfg.ScrapeInterval)
 	}
 	return notifier.MakeMessage(notifier.Notification, startupMsg)
 }

--- a/example_config.json
+++ b/example_config.json
@@ -24,14 +24,14 @@
         },
         "gateway": {
             "type": "ping",
-            "scrape_interval": 1,
+            "scrape_interval": "1s",
             "params": {
                 "target": "192.168.0.1"
             }
         },
         "ethernet_available": {
             "type": "ping",
-            "scrape_interval": 120,
+            "scrape_interval": "2m",
             "params": {
                 "targets": ["8.8.8.8"],
                 "retry_count":3

--- a/pkg/scraping/provider/config.go
+++ b/pkg/scraping/provider/config.go
@@ -3,12 +3,13 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type Config struct {
 	Type           string         `json:"type"`
-	ScrapeInterval uint           `json:"scrape_interval" default:"120"` // scrape interval in seconds
-	Params         map[string]any `json:"params" default:"{}"`           // extra parameters
+	ScrapeInterval time.Duration  `json:"scrape_interval" default:"120s"` // scrape interval
+	Params         map[string]any `json:"params" default:"{}"`            // extra parameters
 }
 
 func LoadProviderFromConfig(ctx context.Context, cfg Config) (Provider, error) {

--- a/pkg/scraping/schedule_scraping.go
+++ b/pkg/scraping/schedule_scraping.go
@@ -38,7 +38,7 @@ func ScheduleScraping(ctx context.Context, providerCfgList map[string]provider.C
 		updateTaskList := providerInstance.GetUpdateTaskList(ctx, &resultWrapper, storage.NewSubStorage(storageInstance, providerName+"/"))
 
 		for _, updateTask := range updateTaskList {
-			taskList = append(taskList, scheduler.MakePeriodicTask(updateTask, time.Second*time.Duration(providerCfg.ScrapeInterval)))
+			taskList = append(taskList, scheduler.MakePeriodicTask(updateTask, providerCfg.ScrapeInterval))
 		}
 	}
 

--- a/pkg/utils/map_on_struct_test.go
+++ b/pkg/utils/map_on_struct_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/mcarbonne/minimal-server-monitoring/pkg/utils"
 	"gotest.tools/v3/assert"
@@ -13,10 +14,28 @@ type subStruct struct {
 }
 
 type testStruct struct {
-	Int              int               `json:"int"`
-	IntDefault       int               `json:"int_d" default:"-3"`
-	Uint             uint              `json:"uint"`
-	UintDefault      uint              `json:"uint_d" default:"9"`
+	Int          int   `json:"int"`
+	IntDefault   int   `json:"int_d" default:"-3"`
+	Int8         int8  `json:"int8"`
+	Int8Default  int8  `json:"int8_d" default:"-4"`
+	Int16        int16 `json:"int16"`
+	Int16Default int16 `json:"int16_d" default:"-5"`
+	Int32        int32 `json:"int32"`
+	Int32Default int32 `json:"int32_d" default:"-6"`
+	Int64        int64 `json:"int64"`
+	Int64Default int64 `json:"int64_d" default:"-7"`
+
+	Uint          uint   `json:"uint"`
+	UintDefault   uint   `json:"uint_d" default:"9"`
+	Uint8         uint8  `json:"uint8"`
+	Uint8Default  uint8  `json:"uint8_d" default:"10"`
+	Uint16        uint16 `json:"uint16"`
+	Uint16Default uint16 `json:"uint16_d" default:"11"`
+	Uint32        uint32 `json:"uint32"`
+	Uint32Default uint32 `json:"uint32_d" default:"12"`
+	Uint64        uint64 `json:"uint64"`
+	Uint64Default uint64 `json:"uint64_d" default:"13"`
+
 	Str              string            `json:"str"`
 	StrDefault       string            `json:"str_d" default:"default_str"`
 	Slice            []int             `json:"slice_int"`
@@ -25,16 +44,27 @@ type testStruct struct {
 	MapEmpty         map[string]string `json:"map_str_empty" default:"{}"`
 	Struct           subStruct         `json:"struct"`
 	StructNotPresent subStruct         `json:"struct_to_present" default:"{}"`
+	Duration         time.Duration     `json:"duration"`
+	DurationDefault  time.Duration     `json:"duration_d" default:"6s"`
 }
 
 func TestMapOnStruct1(t *testing.T) {
 	var rawJson map[string]any
 	myJsonString := `{"int":-5,
+	"int8":-6,
+	"int16":-7,
+	"int32":-8,
+	"int64":-9,
 	"uint":7,
+	"uint8":8,
+	"uint16":9,
+	"uint32":10,
+	"uint64":11,
 	"str":"str",
 	"slice_int":[1,2,3],
 	"map_str": {"a":"abc", "b":"def"},
-	"struct": {"int":5}
+	"struct": {"int":5},
+	"duration":"5s"
 	}`
 	json.Unmarshal([]byte(myJsonString), &rawJson)
 	data, err := utils.MapOnStruct[testStruct](rawJson)
@@ -44,8 +74,26 @@ func TestMapOnStruct1(t *testing.T) {
 
 	assert.Equal(t, data.Int, -5)
 	assert.Equal(t, data.IntDefault, -3)
+	assert.Equal(t, data.Int8, int8(-6))
+	assert.Equal(t, data.Int8Default, int8(-4))
+	assert.Equal(t, data.Int16, int16(-7))
+	assert.Equal(t, data.Int16Default, int16(-5))
+	assert.Equal(t, data.Int32, int32(-8))
+	assert.Equal(t, data.Int32Default, int32(-6))
+	assert.Equal(t, data.Int64, int64(-9))
+	assert.Equal(t, data.Int64Default, int64(-7))
+
 	assert.Equal(t, data.Uint, uint(7))
 	assert.Equal(t, data.UintDefault, uint(9))
+	assert.Equal(t, data.Uint8, uint8(8))
+	assert.Equal(t, data.Uint8Default, uint8(10))
+	assert.Equal(t, data.Uint16, uint16(9))
+	assert.Equal(t, data.Uint16Default, uint16(11))
+	assert.Equal(t, data.Uint32, uint32(10))
+	assert.Equal(t, data.Uint32Default, uint32(12))
+	assert.Equal(t, data.Uint64, uint64(11))
+	assert.Equal(t, data.Uint64Default, uint64(13))
+
 	assert.Equal(t, data.Str, "str")
 	assert.Equal(t, data.StrDefault, "default_str")
 	assert.DeepEqual(t, data.Slice, []int{1, 2, 3})
@@ -53,4 +101,7 @@ func TestMapOnStruct1(t *testing.T) {
 	assert.DeepEqual(t, data.Map, map[string]string{"a": "abc", "b": "def"})
 	assert.DeepEqual(t, data.MapEmpty, map[string]string{})
 	assert.DeepEqual(t, data.Struct, subStruct{Int: 5})
+
+	assert.Equal(t, data.Duration, time.Second*5)
+	assert.Equal(t, data.DurationDefault, time.Second*6)
 }


### PR DESCRIPTION
- implement time.Duration parsing in config parser
- use `time.ParseDuration()` for `scrape_interval`