### PR TITLE
Fix a (rare) bug when trying to inspect a deleted container.

### DIFF
--- a/pkg/scraping/provider/container.go
+++ b/pkg/scraping/provider/container.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/mcarbonne/minimal-server-monitoring/pkg/logging"
 	"github.com/mcarbonne/minimal-server-monitoring/pkg/storage"
 )
 
@@ -88,6 +89,8 @@ func (containerProvider *ProviderContainer) GetUpdateTaskList(ctx context.Contex
 				inspect, err := containerProvider.client.ContainerInspect(ctx, ctr.ID)
 				if err == nil {
 					containerProvider.updateRestartCountMetric(resultWrapper, ctr, inspect)
+				} else if client.IsErrNotFound(err) {
+					logging.Info("Container %v does not exist anymore, ignoring", ctr.ID)
 				} else {
 					inspectErrorList = append(inspectErrorList, err)
 				}


### PR DESCRIPTION
Fix a bug when a container was deleted during scraping.
If container inspection failed because container had been deleted in the meantime, an alert was sent for no reason.