### PR TITLE
Fix metric state machine bug

### DIFF
--- a/pkg/alert/metric_state_machine.go
+++ b/pkg/alert/metric_state_machine.go
@@ -81,24 +81,16 @@ func (msm *MetricStateMachine) Update(metricState provider.MetricState, now time
 
 	// Special case: if service is removed, we want to clear the alert immediately
 	if !msm.isHealthy && metricState.Status == provider.Removed {
-		msm.isHealthy = true
-		msm.oppositeInARow = 0
-		msm.reminderCounter = 0
-		msm.lastFailureMessage = time.Time{}
-		return makeMessage(notifier.Recovery, "removed", metricState.Name, metricState.Description)
+		return msm.transitionToHealthy(metricState.Name, metricState.Description, "removed")
 	}
 
 	if msm.isHealthy {
 		if msm.oppositeInARow >= msm.unhealthyThreshold {
-			msm.isHealthy = false
-			msm.lastFailureMessage = now
-			msm.reminderCounter = 0
-			return makeMessage(notifier.Failure, "failed", metricState.Name, metricState.Description)
+			return msm.transitionToUnhealthy(metricState.Name, metricState.Description, now)
 		}
 	} else {
 		if msm.oppositeInARow >= msm.healthyThreshold {
-			msm.isHealthy = true
-			return makeMessage(notifier.Recovery, "recovered", metricState.Name, metricState.Description)
+			return msm.transitionToHealthy(metricState.Name, metricState.Description, "recovered")
 		} else if msm.shouldRemind(now) {
 			msm.lastFailureMessage = now
 			msm.reminderCounter++
@@ -107,4 +99,20 @@ func (msm *MetricStateMachine) Update(metricState provider.MetricState, now time
 
 	}
 	return nil
+}
+
+func (msm *MetricStateMachine) transitionToUnhealthy(name, description string, now time.Time) *notifier.Message {
+	msm.isHealthy = false
+	msm.oppositeInARow = 0
+	msm.lastFailureMessage = now
+	msm.reminderCounter = 0
+	return makeMessage(notifier.Failure, "failed", name, description)
+}
+
+func (msm *MetricStateMachine) transitionToHealthy(name, description string, reason string) *notifier.Message {
+	msm.isHealthy = true
+	msm.oppositeInARow = 0
+	msm.reminderCounter = 0
+	msm.lastFailureMessage = time.Time{}
+	return makeMessage(notifier.Recovery, reason, name, description)
 }

--- a/pkg/alert/metric_state_machine_test.go
+++ b/pkg/alert/metric_state_machine_test.go
@@ -101,7 +101,7 @@ func TestMetricStateMachine_Thresholds(t *testing.T) {
 	msm := MakeMetricStateMachine(2, 3, 1*time.Hour, 3, customtypes.TimeOfDay{Hour: 8, Minute: 0})
 	metricID := "test_metric"
 	metricName := "Test Metric"
-	now := time.Now()
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	update := func(status provider.MetricStatus) *notifier.Message {
 		return msm.Update(provider.MetricState{MetricID: metricID, Name: metricName, Status: status}, now)

--- a/pkg/alert/metric_state_machine_test.go
+++ b/pkg/alert/metric_state_machine_test.go
@@ -96,6 +96,60 @@ func TestMetricStateMachine_SmartReminders(t *testing.T) {
 	assert.Assert(t, isContains(msg.Message, "reminder"))
 }
 
+func TestMetricStateMachine_Thresholds(t *testing.T) {
+	// Setup: Unhealthy requires 3, Healthy requires 2
+	msm := MakeMetricStateMachine(2, 3, 1*time.Hour, 3, customtypes.TimeOfDay{Hour: 8, Minute: 0})
+	metricID := "test_metric"
+	metricName := "Test Metric"
+	now := time.Now()
+
+	update := func(status provider.MetricStatus) *notifier.Message {
+		return msm.Update(provider.MetricState{MetricID: metricID, Name: metricName, Status: status}, now)
+	}
+
+	// 1. Initial state: Healthy
+	assert.Equal(t, true, msm.isHealthy)
+
+	// 2. First failure: remains healthy
+	assert.Assert(t, update(provider.Unhealthy) == nil)
+	assert.Equal(t, true, msm.isHealthy)
+
+	// 3. Second failure: remains healthy
+	assert.Assert(t, update(provider.Unhealthy) == nil)
+	assert.Equal(t, true, msm.isHealthy)
+
+	// 4. Interrupted by a Success: counter resets
+	assert.Assert(t, update(provider.Healthy) == nil)
+	assert.Equal(t, true, msm.isHealthy)
+	assert.Equal(t, uint(0), msm.oppositeInARow)
+
+	// 5. Restart failures: 1, 2
+	assert.Assert(t, update(provider.Unhealthy) == nil)
+	assert.Assert(t, update(provider.Unhealthy) == nil)
+
+	// 6. Third failure: becomes unhealthy
+	msg := update(provider.Unhealthy)
+	assert.Assert(t, msg != nil)
+	assert.Equal(t, notifier.Failure, msg.Type)
+	assert.Equal(t, false, msm.isHealthy)
+
+	// 7. First recovery: remains unhealthy
+	assert.Assert(t, update(provider.Healthy) == nil)
+	assert.Equal(t, false, msm.isHealthy)
+
+	// 8. Interrupted by a Failure: counter resets
+	assert.Assert(t, update(provider.Unhealthy) == nil)
+	assert.Equal(t, false, msm.isHealthy)
+	assert.Equal(t, uint(0), msm.oppositeInARow)
+
+	// 9. Second recovery attempt: 1, 2
+	assert.Assert(t, update(provider.Healthy) == nil)
+	msg = update(provider.Healthy)
+	assert.Assert(t, msg != nil)
+	assert.Equal(t, notifier.Recovery, msg.Type)
+	assert.Equal(t, true, msm.isHealthy)
+}
+
 func TestMetricStateMachine_Removal(t *testing.T) {
 	// Setup with high threshold
 	msm := MakeMetricStateMachine(10, 1, 1*time.Hour, 3, customtypes.TimeOfDay{Hour: 8, Minute: 0})


### PR DESCRIPTION
The `oppositeInARow` counter was not reset upon state transitions, causing immediate "bounce-back" recoveries or failures if the other threshold was lower than the current counter.
